### PR TITLE
[Monitor] Excludes .yarn from snyk monitors

### DIFF
--- a/snyk/snyk_monitor.yml
+++ b/snyk/snyk_monitor.yml
@@ -22,4 +22,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: monitor
-          args:  snyk monitor --strict-out-of-sync=false --all-projects --tags=repo=${{ github.event.repository.name }}
+          args:  snyk monitor --strict-out-of-sync=false --all-projects --exclude=".yarn" --tags=repo=${{ github.event.repository.name }}


### PR DESCRIPTION
In various Grafana Labs repos the .yarn directory is committed into the Git repo. This includes the `.yarn/sdks` repository which according to the docs contain IDE/editor configuration for TypeScript to work when using Plug'n'Play installs. 
 These sdks contain their own package.json files which snyk picks up and scans as projects. 
 
 This PR directs snyk to exclude the .snyk repository.