### PR TITLE
fix(dependabot-automerge): create `requires-manual-approval` label

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -56,9 +56,11 @@ jobs:
         if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' && steps.dependabot-metadata.outputs.dependency-type == 'direct:production' && !contains(fromJSON(inputs.packages-minor-autoupdate), steps.dependabot-metadata.outputs.dependency-names) }}
         run: |
           gh pr comment $PR_URL --body "**Not approving** minor update to a non-allowlisted production dependency"
+          gh label create requires-manual-approval || true
           gh pr edit $PR_URL --add-label "requires-manual-approval"
       - name: Comment on major updates of production dependencies
         if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-major' && steps.dependabot-metadata.outputs.dependency-type == 'direct:production' }}
         run: |
           gh pr comment $PR_URL --body "**Not approving** major update to a production dependency"
+          gh label create requires-manual-approval || true
           gh pr edit $PR_URL --add-label "requires-manual-approval"


### PR DESCRIPTION

If the label `requires-manual-approval` does not exist in the repo, adding the label fails. See example: https://github.com/grafana/mimir-proxies/actions/runs/12375518398/job/34540501291?pr=234