### PR TITLE
add zizmor to run periodically

### DIFF
--- a/.github/workflows/periodic-zizmor.yaml
+++ b/.github/workflows/periodic-zizmor.yaml
@@ -94,4 +94,6 @@ jobs:
         with:
           sarif_file: ./results.sarif
           token: ${{ steps.get-token.outputs.token }}
+          external-repository-token: ${{ steps.get-token.outputs.token }}
           checkout_path: ./target
+          category: zizmor-periodic

--- a/.github/workflows/periodic-zizmor.yaml
+++ b/.github/workflows/periodic-zizmor.yaml
@@ -1,0 +1,95 @@
+name: Periodic Zizmor
+
+permissions: {}
+
+on:
+  schedule:
+    # Set to run once a day at 10:00 UTC
+    - cron: "0 10 * * *"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repository:
+          #   - owner: grafana
+          #     repo: grafana
+          #   - owner: grafana
+          #     repo: loki
+          #   - owner: grafana
+          #     repo: tempo
+          #   - owner: grafana
+          #     repo: mimir
+          - owner: grafana
+            repo: security-github-actions
+
+    env:
+      ZIZMOR_VERSION: 1.6.0
+      MIN_SEVERITY: high
+      MIN_CONFIDENCE: low
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Get GitHub App Secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.2.0
+        with:
+          common_secrets: |
+            ZIZMOR_APP_ID=zizmor:app-id
+            ZIZMOR_PRIVATE_KEY=zizmor:private-key
+          export_env: false
+
+      - name: Authenticate App With GitHub
+        uses: actions/create-github-app-token@v2
+        id: get-token
+        with:
+          app-id: ${{ fromJson(steps.get-secrets.outputs.secrets).ZIZMOR_APP_ID }}
+          private-key: ${{ fromJson(steps.get-secrets.outputs.secrets).ZIZMOR_PRIVATE_KEY }}
+          owner: ${{ matrix.repository.owner }}
+          repositories: |
+            ${{ matrix.repository.repo }}
+
+      - name: Checkout Target
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ matrix.repository.owner }}/${{ matrix.repository.repo }}
+          token: ${{ steps.get-token.outputs.token }}
+          path: target
+
+      - name: Setup UV
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+        with:
+          enable-cache: true
+          activate-environment: true
+          cache-suffix: ${{ env.ZIZMOR_VERSION }}
+          cache-dependency-glob: ""
+
+      - name: Run zizmor
+        env:
+          ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
+          REPOSITORY: ${{ matrix.repository.owner }}/${{ matrix.repository.repo }}
+          GH_TOKEN: ${{ steps.get-token.outputs.token }}
+        shell: sh
+        run: >-
+          uvx zizmor@"${ZIZMOR_VERSION}"
+          --format sarif
+          --min-severity "${MIN_SEVERITY}"
+          --min-confidence "${MIN_CONFIDENCE}"
+          --config .github/zizmor.yml
+          ./target
+          > results.sarif
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@v3.28.17
+        with:
+          sarif_file: ./results.sarif
+          token: ${{ steps.get-token.outputs.token }}
+          checkout_path: ./target

--- a/.github/workflows/periodic-zizmor.yaml
+++ b/.github/workflows/periodic-zizmor.yaml
@@ -123,7 +123,7 @@ jobs:
               commit_sha: SHA,
               ref: REF,
               sarif: SARIF_RESULTS,
-              tool_name: zizmor-centralized,
+              tool_name: "zizmor-centralized",
             });
 
             console.log(response.status);

--- a/.github/workflows/periodic-zizmor.yaml
+++ b/.github/workflows/periodic-zizmor.yaml
@@ -95,7 +95,7 @@ jobs:
         working-directory: ./target
         run: |
           SHA=$(git rev-parse HEAD)
-          REF=$(git rev-parse --symbolic-full-name HEAD)
+          REF=$(git symbolic-ref --quiet HEAD)
 
           echo "sha=${SHA}" >> $GITHUB_OUTPUT
           echo "ref=${REF}" >> $GITHUB_OUTPUT

--- a/.github/workflows/periodic-zizmor.yaml
+++ b/.github/workflows/periodic-zizmor.yaml
@@ -20,18 +20,18 @@ jobs:
     strategy:
       matrix:
         repository:
-          #   - owner: grafana
-          #     repo: grafana
-          #   - owner: grafana
-          #     repo: loki
-          #   - owner: grafana
-          #     repo: tempo
-          #   - owner: grafana
-          #     repo: mimir
           - owner: grafana
-            repo: security-github-actions
+            repo: grafana
             ref: main
-
+          - owner: grafana
+            repo: loki
+            ref: main
+          - owner: grafana
+            repo: tempo
+            ref: main
+          - owner: grafana
+            repo: mimir
+            ref: main
     env:
       ZIZMOR_VERSION: 1.6.0
       MIN_SEVERITY: high

--- a/.github/workflows/periodic-zizmor.yaml
+++ b/.github/workflows/periodic-zizmor.yaml
@@ -66,8 +66,8 @@ jobs:
           repository: ${{ matrix.repository.owner }}/${{ matrix.repository.repo }}
           token: ${{ steps.get-token.outputs.token }}
           path: target
-          fetch-depth: 0
           ref: ${{ matrix.repository.ref }}
+
       - name: Setup UV
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:

--- a/.github/workflows/periodic-zizmor.yaml
+++ b/.github/workflows/periodic-zizmor.yaml
@@ -65,6 +65,7 @@ jobs:
           repository: ${{ matrix.repository.owner }}/${{ matrix.repository.repo }}
           token: ${{ steps.get-token.outputs.token }}
           path: target
+          fetch-depth: 0
 
       - name: Setup UV
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1

--- a/.github/workflows/periodic-zizmor.yaml
+++ b/.github/workflows/periodic-zizmor.yaml
@@ -48,14 +48,13 @@ jobs:
           common_secrets: |
             ZIZMOR_APP_ID=zizmor:app-id
             ZIZMOR_PRIVATE_KEY=zizmor:private-key
-          export_env: false
 
       - name: Authenticate App With GitHub
         uses: actions/create-github-app-token@v2
         id: get-token
         with:
-          app-id: ${{ fromJson(steps.get-secrets.outputs.secrets).ZIZMOR_APP_ID }}
-          private-key: ${{ fromJson(steps.get-secrets.outputs.secrets).ZIZMOR_PRIVATE_KEY }}
+          app-id: ${{ env.ZIZMOR_APP_ID }}
+          private-key: ${{ env.ZIZMOR_PRIVATE_KEY }}
           owner: ${{ matrix.repository.owner }}
           repositories: |
             ${{ matrix.repository.repo }}

--- a/.github/workflows/periodic-zizmor.yaml
+++ b/.github/workflows/periodic-zizmor.yaml
@@ -6,9 +6,6 @@ on:
   schedule:
     # Set to run once a day at 10:00 UTC
     - cron: "0 10 * * *"
-  pull_request:
-    branches:
-      - main
 
 jobs:
   zizmor:

--- a/.github/workflows/periodic-zizmor.yaml
+++ b/.github/workflows/periodic-zizmor.yaml
@@ -89,11 +89,41 @@ jobs:
           ./target
           > results.sarif
 
+      - name: Repository Info
+        id: repo-info
+        working-directory: ./target
+        run: |
+          SHA=$(git rev-parse HEAD)
+          REF=$(git rev-parse --symbolic-full-name HEAD)
+
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          echo "ref=${REF}" >> $GITHUB_OUTPUT
+
+      - name: Prepare SARIF results
+        id: prepare-sarif
+        run: |
+          RESULTS=$(gzip -c results.sarif | base64 -w 0)
+          echo "results=${RESULTS}" >> $GITHUB_OUTPUT
+
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v3.28.17
+        uses: actions/github-script@v7
+        env:
+          OWNER: ${{ matrix.repository.owner }}
+          REPO: ${{ matrix.repository.repo }}
+          SHA: ${{ steps.repo-info.outputs.sha }}
+          REF: ${{ steps.repo-info.outputs.ref }}
+          SARIF_RESULTS: ${{ steps.prepare-sarif.outputs.results }}
         with:
-          sarif_file: ./results.sarif
-          token: ${{ steps.get-token.outputs.token }}
-          external-repository-token: ${{ steps.get-token.outputs.token }}
-          checkout_path: ./target
-          category: zizmor-periodic
+          github-token: ${{ steps.get-token.outputs.token }}
+          script: |
+            const { OWNER, REPO, SHA, REF, SARIF_RESULTS } = process.env;
+
+            const response = await github.rest.codeScanning.uploadSarif({
+              owner: OWNER,
+              repo: REPO,
+              commit_sha: SHA,
+              ref: REF,
+              sarif: SARIF_RESULTS,
+            });
+
+            console.log(response.status);

--- a/.github/workflows/periodic-zizmor.yaml
+++ b/.github/workflows/periodic-zizmor.yaml
@@ -30,6 +30,7 @@ jobs:
           #     repo: mimir
           - owner: grafana
             repo: security-github-actions
+            ref: main
 
     env:
       ZIZMOR_VERSION: 1.6.0
@@ -66,7 +67,7 @@ jobs:
           token: ${{ steps.get-token.outputs.token }}
           path: target
           fetch-depth: 0
-
+          ref: ${{ matrix.repository.ref }}
       - name: Setup UV
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:
@@ -95,10 +96,7 @@ jobs:
         working-directory: ./target
         run: |
           SHA=$(git rev-parse HEAD)
-          REF=$(git symbolic-ref --quiet HEAD)
-
           echo "sha=${SHA}" >> $GITHUB_OUTPUT
-          echo "ref=${REF}" >> $GITHUB_OUTPUT
 
       - name: Prepare SARIF results
         id: prepare-sarif
@@ -112,7 +110,7 @@ jobs:
           OWNER: ${{ matrix.repository.owner }}
           REPO: ${{ matrix.repository.repo }}
           SHA: ${{ steps.repo-info.outputs.sha }}
-          REF: ${{ steps.repo-info.outputs.ref }}
+          REF: refs/heads/${{ matrix.repository.ref }}
           SARIF_RESULTS: ${{ steps.prepare-sarif.outputs.results }}
         with:
           github-token: ${{ steps.get-token.outputs.token }}

--- a/.github/workflows/periodic-zizmor.yaml
+++ b/.github/workflows/periodic-zizmor.yaml
@@ -123,6 +123,7 @@ jobs:
               commit_sha: SHA,
               ref: REF,
               sarif: SARIF_RESULTS,
+              tool_name: zizmor-centralized,
             });
 
             console.log(response.status);

--- a/.github/workflows/periodic-zizmor.yaml
+++ b/.github/workflows/periodic-zizmor.yaml
@@ -14,6 +14,9 @@ jobs:
   zizmor:
     name: Run zizmor
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         repository:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,16 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": hash-pin
+        actions/*: any
+        github/*: any
+        grafana/*: any
+  forbidden-uses:
+    config:
+      deny:
+        # Policy-banned by our security team due to CVE-2025-30066 & CVE-2025-30154.
+        # https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066-and-reviewdogaction
+        # https://nvd.nist.gov/vuln/detail/cve-2025-30066
+        # https://nvd.nist.gov/vuln/detail/cve-2025-30154
+        - reviewdog/*


### PR DESCRIPTION
Adds zizmor to run periodically (daily) against LGTM repositories, results can be seen at:

[Grafana](https://github.com/grafana/grafana/security/code-scanning/tools/zizmor/status)
[Loki](https://github.com/grafana/loki/security/code-scanning/tools/zizmor/status)
[Mimir](https://github.com/grafana/mimir/security/code-scanning/tools/zizmor/status)
[Tempo](https://github.com/grafana/tempo/security/code-scanning/tools/zizmor/status)

These checks run in online mode, which runs some additional checks to the org-wide ruleset runs