### PR TITLE
enable forks to run

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -41,7 +41,7 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@8ce69f8316247b9c75380ddb1f69df42d6d3a913
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@6b7528b5d783ea798a1f9f20906c4a0da69be914
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: never


### PR DESCRIPTION
Reusable zizmor was failing on forks of public repositories. This bumps to the fixed version of the action