### PR TITLE
fix(dependabot-automerge): calling gh label without repository

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -57,11 +57,11 @@ jobs:
         if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' && steps.dependabot-metadata.outputs.dependency-type == 'direct:production' && !contains(fromJSON(inputs.packages-minor-autoupdate), steps.dependabot-metadata.outputs.dependency-names) }}
         run: |
           gh pr comment $PR_URL --body "**Not approving** minor update to a non-allowlisted production dependency"
-          gh label create requires-manual-approval || true
+          gh label create "requires-manual-approval" --repo "$GITHUB_REPOSITORY" || true
           gh pr edit $PR_URL --add-label "requires-manual-approval"
       - name: Comment on major updates of production dependencies
         if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-major' && steps.dependabot-metadata.outputs.dependency-type == 'direct:production' }}
         run: |
           gh pr comment $PR_URL --body "**Not approving** major update to a production dependency"
-          gh label create requires-manual-approval || true
+          gh label create "requires-manual-approval" --repo "$GITHUB_REPOSITORY" || true
           gh pr edit $PR_URL --add-label "requires-manual-approval"


### PR DESCRIPTION
Workflows fail with
failed to run git: fatal: not a git repository  (or any of the parent directories): .git

The problem is that there is no checkout sometimes when this action is called, thus no git directory.
See https://github.com/grafana/otlp-gateway/actions/runs/16214262982/job/45780063018

Easy fix is to just provide the repo name.
Run with the fix: https://github.com/grafana/otlp-gateway/actions/runs/16214873280/job/45781910070?pr=375