### PR TITLE
Switch TruffleHog to monitoring mode (non-blocking)

### DIFF
--- a/.github/workflows/org-required-trufflehog.yml
+++ b/.github/workflows/org-required-trufflehog.yml
@@ -20,8 +20,8 @@ jobs:
     name: TruffleHog Secret Scan
     uses: ./.github/workflows/reusable-trufflehog.yml
     with:
-      # Simplified workflow - only what you need
-      fail-on-verified: "true"       # Always fail on real secrets
-      fail-on-unverified: "false"    # Lenient for org-wide adoption
+      # Monitoring mode - no blocking, just reporting
+      fail-on-verified: "false"      # Don't block on verified secrets (monitoring only)
+      fail-on-unverified: "false"    # Don't block on unverified secrets
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-x86-large' }}    # Large runner for internal repositories
     secrets: inherit


### PR DESCRIPTION
- Set fail-on-verified to false - won't block PRs on verified secrets
- Set fail-on-unverified to false - won't block PRs on unverified secrets
- Workflow will still scan and post PR comments for visibility
- Allows gradual rollout and monitoring before enforcing blocking mode
- Can be switched back to blocking mode later by changing to true