### PR TITLE
Allow merge groups to trigger the self-zizmor workflow

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -6,6 +6,8 @@ on:
   pull_request:
     paths:
       - ".github/**"
+  merge_group:
+    types: [checks_requested]
 jobs:
   zizmor-check:
     name: Check whether there are things to scan


### PR DESCRIPTION
Currently merge groups can't trigger the self-zizmor workflow and remain stuck, this allows the trigger to the workflow to allow these types of commits to succeed CI and get properly merged to the default branch.

I added the `types` filter although that filter is ignored to make it explicit, currently `paths` are used as filter for other triggers and is also ignored by the ruleset, we might want to revise our triggers and make it explicit that the workflow only supports these triggers: https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#supported-event-triggers