### PR TITLE
Fix architecture detection for cross-platform TruffleHog support

### DIFF
--- a/.github/workflows/reusable-trufflehog.yml
+++ b/.github/workflows/reusable-trufflehog.yml
@@ -42,7 +42,12 @@ jobs:
         run: |
           # Download binary directly from GitHub releases for supply chain security
           VERSION="v${{ env.TRUFFLEHOG_VERSION }}"
-          ARCH="linux_amd64"
+          # Auto-detect architecture for cross-platform support
+          if [[ "$(uname -m)" == "aarch64" ]]; then
+            ARCH="linux_arm64"
+          else
+            ARCH="linux_amd64"
+          fi
           BINARY_URL="https://github.com/trufflesecurity/trufflehog/releases/download/${VERSION}/trufflehog_${VERSION#v}_${ARCH}.tar.gz"
 
           curl -sSfL "${BINARY_URL}" | tar -xz -C /tmp


### PR DESCRIPTION
- Auto-detect runner architecture (aarch64 vs x86_64)
- Download correct binary (linux_arm64 vs linux_amd64)
- Fixes 'cannot execute binary file: Exec format error' on ARM64 runners
- Supports both ubuntu-arm64-small and ubuntu-latest runners