### PR TITLE
fix(self-zizmor): trigger on ready-for-review

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -9,6 +9,7 @@ on:
       - opened
       - ready_for_review
       - synchronize
+      - reopened
     paths:
       - ".github/**"
   merge_group:


### PR DESCRIPTION
If this is used as part of a release-please enabled repository, then this additional pull_request event type is needed to trigger zizmor on the release pull request.