### PR TITLE
Add Semgrep static analysis workflow for create-github-app-token action detection

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -32,7 +32,7 @@ jobs:
           GITHUB_BRANCH: ${{github.head_ref || github.ref_name}}
         run: |
           set +e
-          semgrep scan --error --json --config security-github-actions/semgrep/custom-rules.yaml > /tmp/semgrep-results.json 2>/dev/null
+          semgrep scan --error --json --config security-github-actions/semgrep/custom-rules.yaml > /tmp/semgrep-results.json
           EXIT_CODE=$?
           set -e
           if [ $EXIT_CODE -eq 1 ]; then

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -15,10 +15,10 @@ jobs:
       image: semgrep/semgrep:1.152.0
     steps:
       # Fetch project source with GitHub Actions Checkout.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Fetch org-wide custom Semgrep rules from the central repository.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: grafana/security-github-actions
           ref: ${{ github.repository == 'grafana/security-github-actions' && (github.head_ref || github.ref_name) || '' }}
@@ -26,7 +26,6 @@ jobs:
             semgrep/custom-rules.yaml
             semgrep/format-results.sh
           path: security-github-actions
-      # Run semgrep with: auto rules + org-wide shared rules
       - id: semgrep
         env:
           GITHUB_REPOSITORY: ${{github.repository}}

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,64 @@
+name: Semgrep static analysis
+on:
+  pull_request:
+jobs:
+  semgrep:
+    permissions:
+      contents: read
+      pull-requests: write
+    # User definable name of this GitHub Actions job.
+    name: semgrep-oss/scan
+    # If you are self-hosting, change the following `runs-on` value:
+    runs-on: ubuntu-latest
+    container:
+      # A Docker image with Semgrep installed. Do not change this.
+      image: semgrep/semgrep:1.152.0
+    steps:
+      # Fetch project source with GitHub Actions Checkout.
+      - uses: actions/checkout@v4
+
+      # Fetch org-wide custom Semgrep rules from the central repository.
+      - uses: actions/checkout@v4
+        with:
+          repository: grafana/security-github-actions
+          ref: ${{ github.repository == 'grafana/security-github-actions' && (github.head_ref || github.ref_name) || '' }}
+          sparse-checkout: |
+            semgrep/custom-rules.yaml
+            semgrep/format-results.sh
+          path: security-github-actions
+      # Run semgrep with: auto rules + org-wide shared rules
+      - id: semgrep
+        env:
+          GITHUB_REPOSITORY: ${{github.repository}}
+          GITHUB_BRANCH: ${{github.head_ref || github.ref_name}}
+        run: |
+          set +e
+          semgrep scan --error --json --config security-github-actions/semgrep/custom-rules.yaml > /tmp/semgrep-results.json 2>/dev/null
+          EXIT_CODE=$?
+          set -e
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "has_findings=true" >> "$GITHUB_OUTPUT"
+            {
+              echo 'SEMGREP_OUTPUT<<SEMGREP_EOF'
+              bash security-github-actions/semgrep/format-results.sh /tmp/semgrep-results.json
+              echo 'SEMGREP_EOF'
+            } >> "$GITHUB_ENV"
+          fi
+
+          HIGH_CRITICAL=$(jq '[.results[] | select(.extra.severity == "HIGH" or .extra.severity == "CRITICAL")] | length' /tmp/semgrep-results.json)
+          if [ "$HIGH_CRITICAL" -gt 0 ]; then
+            echo "has_high_critical=true" >> "$GITHUB_OUTPUT"
+          fi
+        continue-on-error: true
+
+      - if: steps.semgrep.outputs.has_findings == 'true'
+        uses: int128/comment-action@66317511bc86c47bd51e03059040e8a460a167b8
+        with:
+          update-if-exists: recreate
+          post: |
+            ${{ env.SEMGREP_OUTPUT }}
+
+      - if: steps.semgrep.outputs.has_high_critical == 'true'
+        run: |
+          echo "::error::Semgrep found HIGH or CRITICAL severity findings."
+          exit 1

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -47,13 +47,13 @@ jobs:
           if [ $EXIT_CODE -gt 1 ]; then
             echo "::error::Semgrep run encounters an error"
             cat /tmp/semgrep-results.json
+            exit 1
           fi
 
           HIGH_CRITICAL=$(jq '[.results[] | select(.extra.severity == "HIGH" or .extra.severity == "CRITICAL")] | length' /tmp/semgrep-results.json)
           if [ "$HIGH_CRITICAL" -gt 0 ]; then
             echo "has_high_critical=true" >> "$GITHUB_OUTPUT"
           fi
-        continue-on-error: true
 
       - if: steps.semgrep.outputs.has_findings == 'true'
         uses: int128/comment-action@66317511bc86c47bd51e03059040e8a460a167b8

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -35,13 +35,18 @@ jobs:
           semgrep scan --error --json --config security-github-actions/semgrep/custom-rules.yaml > /tmp/semgrep-results.json 2>/dev/null
           EXIT_CODE=$?
           set -e
-          if [ $EXIT_CODE -ne 0 ]; then
+          if [ $EXIT_CODE -eq 1 ]; then
             echo "has_findings=true" >> "$GITHUB_OUTPUT"
             {
               echo 'SEMGREP_OUTPUT<<SEMGREP_EOF'
               bash security-github-actions/semgrep/format-results.sh /tmp/semgrep-results.json
               echo 'SEMGREP_EOF'
             } >> "$GITHUB_ENV"
+          fi
+
+          if [ $EXIT_CODE -gt 1 ]; then
+            echo "::error::Semgrep run encounters an error"
+            cat /tmp/semgrep-results.json
           fi
 
           HIGH_CRITICAL=$(jq '[.results[] | select(.extra.severity == "HIGH" or .extra.severity == "CRITICAL")] | length' /tmp/semgrep-results.json)

--- a/semgrep/custom-rules.yaml
+++ b/semgrep/custom-rules.yaml
@@ -1,8 +1,8 @@
 rules:
   - id: deny-actions-create-github-app-token
-    patterns:
+    pattderns:
       - pattern-regex: "uses:\\s*actions/create-github-app-token"
-    paths:
+    passths:
       include:
         - "*.yaml"
         - "*.yml"

--- a/semgrep/custom-rules.yaml
+++ b/semgrep/custom-rules.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: deny-actions-create-github-app-token
+    patterns:
+      - pattern-regex: "uses:\\s*actions/create-github-app-token"
+    paths:
+      include:
+        - "*.yaml"
+        - "*.yml"
+    message: >
+      Do not use actions/create-github-app-token. Use the organization's
+      approved [alternative for generating GitHub App tokens](https://enghub.grafana-ops.net/docs/default/component/deployment-tools/platform/vault/github-app-token-broker-migration-guide/).
+    languages: [generic]
+    severity: LOW

--- a/semgrep/custom-rules.yaml
+++ b/semgrep/custom-rules.yaml
@@ -1,8 +1,8 @@
 rules:
   - id: deny-actions-create-github-app-token
-    pattderns:
+    patterns:
       - pattern-regex: "uses:\\s*actions/create-github-app-token"
-    passths:
+    paths:
       include:
         - "*.yaml"
         - "*.yml"

--- a/semgrep/format-results.sh
+++ b/semgrep/format-results.sh
@@ -17,12 +17,12 @@ echo ""
 echo "| Severity | Rule | File | Message |"
 echo "|----------|------|------|---------|"
 
-jq -r --arg repo "$GITHUB_REPOSITORY" --arg branch "$GITHUB_BRANCH" '.results[] | {
+jq -r --arg repo "$GITHUB_REPOSITORY" --arg sha "$GITHUB_SHA" '.results[] | {
   sev: .extra.severity,
   rule: (.check_id | split(".")[-1]),
   path: .path,
   line: .start.line,
-  msg: (.extra.message | gsub("\n"; " ") | ltrimstr(" ") | rtrimstr(" "))
+  msg: (.extra.message | gsub("\n"; " ") | ltrimstr(" ") | rtrimstr(" ") | gsub("\\|"; "\\|") | gsub("`"; "\\`"))
 } | {
   icon: (if .sev == "CRITICAL" then "🔴"
          elif .sev == "HIGH" then "🟠"
@@ -35,4 +35,4 @@ jq -r --arg repo "$GITHUB_REPOSITORY" --arg branch "$GITHUB_BRANCH" '.results[] 
   path: .path,
   line: .line,
   msg: .msg
-} | "| \(.icon) \(.sev) | `\(.rule)` | [`\(.path):\(.line)`](https://github.com/\($repo)/blob/\($branch)/\(.path)#L\(.line)) | \(.msg) |"' "$INPUT_FILE"
+} | "| \(.icon) \(.sev) | `\(.rule)` | [`\(.path):\(.line)`](https://github.com/\($repo)/blob/\($sha)/\(.path)#L\(.line)) | \(.msg) |"' "$INPUT_FILE"

--- a/semgrep/format-results.sh
+++ b/semgrep/format-results.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Format semgrep JSON results into a GitHub-flavored markdown comment.
+set -euo pipefail
+
+INPUT_FILE="$1"
+
+RESULTS_COUNT=$(jq '.results | length' "$INPUT_FILE")
+
+if [ "$RESULTS_COUNT" -eq 0 ]; then
+  exit 0
+fi
+
+echo "## Semgrep Findings"
+echo ""
+echo "**${RESULTS_COUNT}** finding(s) detected."
+echo ""
+echo "| Severity | Rule | File | Message |"
+echo "|----------|------|------|---------|"
+
+jq -r --arg repo "$GITHUB_REPOSITORY" --arg branch "$GITHUB_BRANCH" '.results[] | {
+  sev: .extra.severity,
+  rule: (.check_id | split(".")[-1]),
+  path: .path,
+  line: .start.line,
+  msg: (.extra.message | gsub("\n"; " ") | ltrimstr(" ") | rtrimstr(" "))
+} | {
+  icon: (if .sev == "CRITICAL" then "🔴"
+         elif .sev == "HIGH" then "🟠"
+         elif .sev == "MEDIUM" then "🟡"
+         elif .sev == "LOW" then "🔵"
+         elif .sev == "INFO" then "⚪"
+         else "⚪" end),
+  sev: .sev,
+  rule: .rule,
+  path: .path,
+  line: .line,
+  msg: .msg
+} | "| \(.icon) \(.sev) | `\(.rule)` | [`\(.path):\(.line)`](https://github.com/\($repo)/blob/\($branch)/\(.path)#L\(.line)) | \(.msg) |"' "$INPUT_FILE"


### PR DESCRIPTION
## Summary

- **New Semgrep workflow** (`.github/workflows/semgrep.yaml`): Runs [Semgrep OSS](https://semgrep.dev/) on every pull request using the official container image (`semgrep/semgrep:1.152.0`). Findings are posted as a PR comment (recreated on each push) and the job fails if any HIGH or CRITICAL severity issues are found.
- **Custom rules** (`semgrep/custom-rules.yaml`): Adds an org-wide rule that flags usage of `actions/create-github-app-token` and points to the approved alternative.
- **Result formatter** (`semgrep/format-results.sh`): Converts Semgrep JSON output into a GitHub-flavored markdown table with severity icons, rule names, file links, and messages.
  - Only post the PR comment when findings are actually found

## Design decisions

- The Semgrep workflow checks out custom rules from the central `grafana/security-github-actions` repo, so consuming repositories get rule updates automatically without changing their own workflows.
- When running inside `security-github-actions` itself, the checkout uses the PR branch (`github.head_ref`) so rule changes can be tested before merging.
- Only `--config custom-rules.yaml` is used (no `--config auto`) to keep the scan focused on org-specific rules.

## Test plan

- [ ] Open a test PR that uses `actions/create-github-app-token` and verify Semgrep posts a comment with the finding
- [ ] Push a fix removing the flagged action and verify the comment is recreated without it

🤖 Generated with [Claude Code](https://claude.com/claude-code)