### PR TITLE
Bump grafana-bench to v1.0.9

### DIFF
--- a/.github/workflows/reusable-trufflehog.yml
+++ b/.github/workflows/reusable-trufflehog.yml
@@ -401,7 +401,7 @@ jobs:
             echo "::error::PROMETHEUS_URL not set; Vault step may have failed."
             exit 1
           fi
-          if ! docker pull ghcr.io/grafana/grafana-bench:v1.0.8; then
+          if ! docker pull ghcr.io/grafana/grafana-bench:v1.0.9; then
             echo "Could not pull Bench image; skipping bench step."
             exit 0
           fi
@@ -417,7 +417,7 @@ jobs:
             -e PROMETHEUS_URL="${PROMETHEUS_URL}" \
             -e PROMETHEUS_USER="${PROMETHEUS_USER}" \
             -e PROMETHEUS_PASSWORD="${PROMETHEUS_PASSWORD}" \
-            ghcr.io/grafana/grafana-bench:v1.0.8 report \
+            ghcr.io/grafana/grafana-bench:v1.0.9 report \
             --report-input trufflehog \
             --service "${BENCH_SERVICE}" \
             --service-version "${BENCH_SERVICE_VERSION}" \


### PR DESCRIPTION
## Summary
- Bumps `ghcr.io/grafana/grafana-bench` Docker image from `v1.0.8` to `v1.0.9`
- v1.0.9 logs each repo-local TruffleHog exclusion pattern individually (`msg=repoExclusion pattern=...`), making them queryable in Loki

## Test plan
- [x] v1.0.9 release exists: https://github.com/grafana/grafana-bench/releases/tag/v1.0.9
- [x] Verify image pulls successfully after merge