### PR TITLE
test: zizmor reusable fork pin for vendor excludes (#326)

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -47,7 +47,8 @@ jobs:
 
     # Testing security-appsec#326: reusable with optional .github/zizmor-collection-ignore. Point org rulesets at
     # branch test/zizmor-vendor-excludes-326 to validate; replace with grafana/shared-workflows@<merge SHA> for main.
-    uses: isaiah-grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@242628b1464cb1ecfb92b208f2bb8aaae795ec63
+    # Pin to fork branch (moves with pushes) for pre-merge testing; switch back to @<SHA> for reproducible runs.
+    uses: isaiah-grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@feat/zizmor-vendor-excludes-326
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -47,8 +47,8 @@ jobs:
 
     # Testing security-appsec#326: reusable with optional .github/zizmor-collection-ignore. Point org rulesets at
     # branch test/zizmor-vendor-excludes-326 to validate; replace with grafana/shared-workflows@<merge SHA> for main.
-    # Pin to fork branch (moves with pushes) for pre-merge testing; switch back to @<SHA> for reproducible runs.
-    uses: isaiah-grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@feat/zizmor-vendor-excludes-326
+    # Pinned to fork SHA (not a branch ref) to satisfy code scanning unpinned-reusable-workflow rules; bump when testing new commits.
+    uses: isaiah-grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@ca9579cb3a5b072b4f75af091380536c01131610
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       # Pilot branch: only fail on critical so high-severity zizmor findings do not block ruleset/PR testing (#326).

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,7 +45,9 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@e7a3275d4c4978a3514801ec55708f1c599a6906
+    # Testing security-appsec#326: reusable with optional .github/zizmor-collection-ignore. Point org rulesets at
+    # branch test/zizmor-vendor-excludes-326 to validate; replace with grafana/shared-workflows@<merge SHA> for main.
+    uses: isaiah-grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@242628b1464cb1ecfb92b208f2bb8aaae795ec63
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high


### PR DESCRIPTION
I used this branch to **test rulesets** against the #326 zizmor change: `self-zizmor` temporarily `uses:` `isaiah-grafana/shared-workflows` @ `242628b…` so we could point rulesets at **`test/zizmor-vendor-excludes-326`** on this repo.

**Don’t merge this to `main`.** Real rollout: merge **https://github.com/grafana/shared-workflows/pull/1861**, then swap the `uses:` line to **`grafana/shared-workflows/...`** @ **merge SHA** here, put rulesets back to **`main`**, and close this.

https://github.com/grafana/security-appsec/issues/326
