### PR TITLE
perf(trufflehog): single process for PR changed-file scan

### DIFF
--- a/.github/workflows/org-required-trufflehog.yml
+++ b/.github/workflows/org-required-trufflehog.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   secret-scan:
     name: TruffleHog Secret Scan
-    uses: grafana/security-github-actions/.github/workflows/reusable-trufflehog.yml@isaiah/trufflehog-single-invocation
+    uses: grafana/security-github-actions/.github/workflows/reusable-trufflehog.yml@main
     with:
       # Non-blocking: job succeeds; PR still gets comments/artifacts when findings exist
       fail-on-verified: "false"      # Set "true" to fail on verified secrets

--- a/.github/workflows/org-required-trufflehog.yml
+++ b/.github/workflows/org-required-trufflehog.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   secret-scan:
     name: TruffleHog Secret Scan
-    uses: grafana/security-github-actions/.github/workflows/reusable-trufflehog.yml@main
+    uses: grafana/security-github-actions/.github/workflows/reusable-trufflehog.yml@isaiah/trufflehog-single-invocation
     with:
       # Non-blocking: job succeeds; PR still gets comments/artifacts when findings exist
       fail-on-verified: "false"      # Set "true" to fail on verified secrets

--- a/.github/workflows/reusable-trufflehog.yml
+++ b/.github/workflows/reusable-trufflehog.yml
@@ -147,28 +147,32 @@ jobs:
             fi
 
             if [[ -s changed-files.txt ]]; then
-              # One TruffleHog per argv batch (not per file): avoids repeated process startup on
-              # large diffs; GNU xargs -0 splits when argv would exceed OS limits.
-              paths=()
+              # One TruffleHog process over repo root; --include-paths file lists anchored regexes
+              # (TruffleHog expects regex lines, not raw paths — see trufflesecurity docs).
+              INCLUDE_REGEXES=/tmp/trufflehog-pr-include-regexes.txt
+              : > "${INCLUDE_REGEXES}"
               while IFS= read -r file; do
                 if [[ -s /tmp/exclude-regexes.txt ]] && echo "$file" | grep -qEf /tmp/exclude-regexes.txt 2>/dev/null; then
                   echo "Skipping: ${file} (matches exclude pattern)"
                   continue
                 fi
                 if [[ -f "${file}" ]]; then
-                  paths+=("${file}")
+                  python3 -c 'import re, sys; print("^" + re.escape(sys.argv[1]) + "$")' "$file" >> "${INCLUDE_REGEXES}"
                 fi
               done < changed-files.txt
 
-              if ((${#paths[@]} > 0)); then
-                echo "TruffleHog: ${#paths[@]} path(s), batched by xargs as needed"
+              if [[ -s "${INCLUDE_REGEXES}" ]]; then
+                sort -u -o "${INCLUDE_REGEXES}" "${INCLUDE_REGEXES}"
+                n_inc=$(wc -l < "${INCLUDE_REGEXES}")
+                echo "TruffleHog: ${n_inc} path(s) via --include-paths (anchored regexes)"
                 : > results.ndjson
-                printf '%s\0' "${paths[@]}" | xargs -0 -r trufflehog filesystem \
+                trufflehog filesystem . \
+                  --include-paths "${INCLUDE_REGEXES}" \
                   --exclude-paths /tmp/trufflehog-exclude.txt \
                   --concurrency 16 \
                   --json \
                   --no-update \
-                  --results=verified,unverified >> results.ndjson || true
+                  --results=verified,unverified > results.ndjson || true
               else
                 echo "No files to scan after excludes (only deletions or excluded paths)"
               fi
@@ -393,7 +397,7 @@ jobs:
       id-token: write
     steps:
       - name: Get Prometheus secrets from Vault
-        uses: grafana/shared-workflows/actions/get-vault-secrets@078c4a8af09e06d646077550f9e0f68171d5881e # get-vault-secrets/v1.3.1
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
         with:
           common_secrets: |
             PROMETHEUS_URL=grafana-bench:prometheus_url

--- a/.github/workflows/reusable-trufflehog.yml
+++ b/.github/workflows/reusable-trufflehog.yml
@@ -147,17 +147,31 @@ jobs:
             fi
 
             if [[ -s changed-files.txt ]]; then
+              # One TruffleHog per argv batch (not per file): avoids repeated process startup on
+              # large diffs; GNU xargs -0 splits when argv would exceed OS limits.
+              paths=()
               while IFS= read -r file; do
                 if [[ -s /tmp/exclude-regexes.txt ]] && echo "$file" | grep -qEf /tmp/exclude-regexes.txt 2>/dev/null; then
                   echo "Skipping: ${file} (matches exclude pattern)"
                   continue
                 fi
-
                 if [[ -f "${file}" ]]; then
-                  echo "Scanning: ${file}"
-                  trufflehog filesystem "${file}" --exclude-paths /tmp/trufflehog-exclude.txt --concurrency 16 --json --no-update --results=verified,unverified >> results.ndjson || true
+                  paths+=("${file}")
                 fi
               done < changed-files.txt
+
+              if ((${#paths[@]} > 0)); then
+                echo "TruffleHog: ${#paths[@]} path(s), batched by xargs as needed"
+                : > results.ndjson
+                printf '%s\0' "${paths[@]}" | xargs -0 -r trufflehog filesystem \
+                  --exclude-paths /tmp/trufflehog-exclude.txt \
+                  --concurrency 16 \
+                  --json \
+                  --no-update \
+                  --results=verified,unverified >> results.ndjson || true
+              else
+                echo "No files to scan after excludes (only deletions or excluded paths)"
+              fi
             else
               echo "No files changed"
             fi
@@ -379,7 +393,7 @@ jobs:
       id-token: write
     steps:
       - name: Get Prometheus secrets from Vault
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
+        uses: grafana/shared-workflows/actions/get-vault-secrets@078c4a8af09e06d646077550f9e0f68171d5881e # get-vault-secrets/v1.3.1
         with:
           common_secrets: |
             PROMETHEUS_URL=grafana-bench:prometheus_url


### PR DESCRIPTION
Run one trufflehog filesystem over all filtered changed paths for pull_request / merge_group instead of one process per file, avoiding repeated startup cost on large diffs.
