### PR TITLE
Set min-confidence to medium

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -49,7 +49,7 @@ jobs:
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high
-      min-severity: high
+      min-severity: medium
       min-confidence: low
       extra-args: --offline
       # Reusable workflow gates bench job on org + non-fork PR (OIDC/Vault not available on fork PRs); pass true to opt in.


### PR DESCRIPTION
The intention of this PR is to include artipacked results in teh zizmor findings which are a medium severity finding. This PR therefor reduces the filter level to medium, whilst still only failing on high findings, this should prevent PRs from being blocked, whilst also adding the findings to a users PR.