### PR TITLE
chore(zizmor): update shared-workflows ref to include PR comment fallback

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,7 +45,7 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@9099825d5ef82fa57e0cf6a263477bc926f51bfa
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@5cec40ba1a943db268a9bb33f208c006b161d372
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high


### PR DESCRIPTION
## Summary

Update the `reusable-zizmor.yml` SHA reference to pick up changes from https://github.com/grafana/shared-workflows/pull/1876.

## Changes in the referenced workflow

- **PR comment is now a fallback:** Only posted when Code Scanning upload fails (private repos without Advanced Security). Public repos only get inline Code Scanning annotations, reducing PR noise.
- **zizmor updated from 1.23.1 to 1.24.1:** Improved SARIF codeflows for better Code Scanning rendering, plus numerous bug fixes.

## Diff

```diff
- uses: grafana/shared-workflows/...@9099825d5ef82fa57e0cf6a263477bc926f51bfa
+ uses: grafana/shared-workflows/...@5cec40ba1a943db268a9bb33f208c006b161d372
```