### PR TITLE
chore: zizmor ruleset pilot branch (#326)

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,7 +45,9 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@5cec40ba1a943db268a9bb33f208c006b161d372
+    # Pilot (#326): reusable from fork branch (not SHA) so ruleset testing tracks latest shared-workflows changes.
+    # Swap back to grafana/shared-workflows@<SHA> on main when done.
+    uses: isaiah-grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@feat/zizmor-vendor-excludes-326
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -47,7 +47,7 @@ jobs:
 
     # Pilot (#326): reusable from fork branch (not SHA) so ruleset testing tracks latest shared-workflows changes.
     # Swap back to grafana/shared-workflows@<SHA> on main when done.
-    uses: isaiah-grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@feat/zizmor-vendor-excludes-326
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@feat/zizmor-vendor-excludes-326
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,9 +45,9 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    # Pilot (#326): reusable from fork branch (not SHA) so ruleset testing tracks latest shared-workflows changes.
-    # Swap back to grafana/shared-workflows@<SHA> on main when done.
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@feat/zizmor-vendor-excludes-326
+    # Pilot (#326): pin to grafana/shared-workflows PR head (feat/zizmor-collection-ignore-326-v2 @ 5cbb63c).
+    # Bump SHA when shared-workflows changes; swap to main pin when rolled out.
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@5cbb63c571adffc041a20b6a057645a8549e6b7c
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -46,7 +46,7 @@ jobs:
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
     # #326 pilot — shared-workflows feat/zizmor-collection-ignore-326-v2 (PR #1945)
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@664db527638a19b4f7a8aa175ec2eff9033fb5cd
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@a0ded699096e4939468a229648b0268340a90c99
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,7 +45,8 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@e6c831d1106c11504502ef164409b2d5479daefe
+    # #326 pilot — shared-workflows feat/zizmor-collection-ignore-326-v2-wip @ b3b177b
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@b3b177b0318e021391347093fed93ab4ade0cf7e
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,8 +45,8 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    # #326 pilot — shared-workflows feat/zizmor-collection-ignore-326-v2-wip
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@59e511f672e096c605f4c4da494da6b8091c0a92
+    # #326 pilot — shared-workflows feat/zizmor-collection-ignore-326-v2 (PR #1944)
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@1f447f273db6a24663c2daf4e1876f1e4298e93b
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,8 +45,8 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    # #326 pilot — shared-workflows feat/zizmor-collection-ignore-326-v2-wip @ b3b177b
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@b3b177b0318e021391347093fed93ab4ade0cf7e
+    # #326 pilot — shared-workflows feat/zizmor-collection-ignore-326-v2-wip
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@59e511f672e096c605f4c4da494da6b8091c0a92
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,8 +45,8 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    # #326 pilot — shared-workflows feat/zizmor-collection-ignore-326-v2 (PR #1944)
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@1f447f273db6a24663c2daf4e1876f1e4298e93b
+    # #326 pilot — shared-workflows feat/zizmor-collection-ignore-326-v2 (PR #1945)
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@664db527638a19b4f7a8aa175ec2eff9033fb5cd
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high

--- a/.github/zizmor-collection-ignore
+++ b/.github/zizmor-collection-ignore
@@ -1,0 +1,2 @@
+# security-appsec#326
+vendor-fixture

--- a/vendor-fixture/.github/workflows/should-not-scan.yml
+++ b/vendor-fixture/.github/workflows/should-not-scan.yml
@@ -1,0 +1,7 @@
+name: vendor fixture
+on: workflow_dispatch
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok


### PR DESCRIPTION
## Summary
Recreates `test/zizmor-vendor-excludes-326` as a **branch on `grafana/security-github-actions`** (same-repo PR into `main`), not from a fork head.

`self-zizmor.yaml` matches `main`: `uses: grafana/shared-workflows/.../reusable-zizmor.yml@5cec40b` (no `isaiah-grafana` fork pin).

Closes the fork-based workflow from the prior PR; org rulesets should point at **this repo + branch**.

Ref: https://github.com/grafana/security-appsec/issues/326
