### PR TITLE
fix(trufflehog): make grafana bench metrics steps non-blocking

### DIFF
--- a/.github/workflows/reusable-trufflehog.yml
+++ b/.github/workflows/reusable-trufflehog.yml
@@ -397,6 +397,7 @@ jobs:
       id-token: write
     steps:
       - name: Get Prometheus secrets from Vault
+        continue-on-error: true
         uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
         with:
           common_secrets: |
@@ -405,11 +406,13 @@ jobs:
             PROMETHEUS_PASSWORD=grafana-bench:prometheus_token
 
       - name: Download TruffleHog scan artifact
+        continue-on-error: true
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: trufflehog_scan
 
       - name: Send TruffleHog metrics to Prometheus via Grafana Bench
+        continue-on-error: true
         env:
           BENCH_SERVICE: ${{ format('grafana-{0}', github.event.repository.name) }}
           BENCH_SUITE_NAME: ${{ github.event.repository.name }}/trufflehog

--- a/.github/workflows/reusable-trufflehog.yml
+++ b/.github/workflows/reusable-trufflehog.yml
@@ -388,6 +388,7 @@ jobs:
 
   grafana-bench:
     name: Send TruffleHog metrics to Prometheus via Grafana Bench
+    continue-on-error: true
     needs: [trufflehog-scan]
     # Only run for grafana org and non-fork PRs (fork PRs have no OIDC/Vault access).
     if: ${{ github.repository_owner == 'grafana' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && inputs.send-bench-metrics && always() && !cancelled() && (needs.trufflehog-scan.result == 'success' || needs.trufflehog-scan.result == 'failure') }}
@@ -397,7 +398,6 @@ jobs:
       id-token: write
     steps:
       - name: Get Prometheus secrets from Vault
-        continue-on-error: true
         uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
         with:
           common_secrets: |
@@ -406,13 +406,11 @@ jobs:
             PROMETHEUS_PASSWORD=grafana-bench:prometheus_token
 
       - name: Download TruffleHog scan artifact
-        continue-on-error: true
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: trufflehog_scan
 
       - name: Send TruffleHog metrics to Prometheus via Grafana Bench
-        continue-on-error: true
         env:
           BENCH_SERVICE: ${{ format('grafana-{0}', github.event.repository.name) }}
           BENCH_SUITE_NAME: ${{ github.event.repository.name }}/trufflehog


### PR DESCRIPTION
This PR makes Grafana Bench metrics job non-blocking for the Trufflehog workflow, so issues with Prometheus credentials, Trufflehog artifact download, or Bench reporting do not fail the underlying Trufflehog check.

This issue came about recently in an incident where expired credentials caused one of the Grafana Bench steps to fail, blocking all PRs requiring a successful check of this workflow.