### PR TITLE
Auto-delete branches with vulnerable workflows detected by zizmor

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -55,3 +55,60 @@ jobs:
       # Reusable workflow gates bench job on org + non-fork PR (OIDC/Vault not available on fork PRs); pass true to opt in.
       send-bench-metrics: true
     secrets: inherit
+
+  delete-vulnerable-branch:
+    name: Delete branch with vulnerable workflow
+    needs:
+      - zizmor
+    if: >-
+      always() &&
+      needs.zizmor.result == 'failure' &&
+      github.event_name == 'push' &&
+      github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - name: Create issue notifying branch author
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
+          SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --repo "${REPO}" \
+            --title "Vulnerable workflow detected — branch \`${REF_NAME}\` deleted" \
+            --assignee "${ACTOR}" \
+            --body "$(cat <<EOF
+          ## Branch auto-deleted due to vulnerable GitHub Actions workflow
+
+          | Field | Value |
+          |---|---|
+          | **Branch** | \`${REF_NAME}\` |
+          | **Pushed by** | @${ACTOR} |
+          | **Commit** | ${SHA} |
+          | **Workflow run** | ${RUN_URL} |
+
+          [zizmor](https://github.com/woodruffw/zizmor) found a high-severity vulnerability in a GitHub Actions workflow on this branch. To prevent exploitation, the branch was automatically deleted.
+
+          ### What to do
+
+          1. Review the [workflow run logs](${RUN_URL}) for details on the finding.
+          2. Fix the vulnerable workflow locally.
+          3. Push the branch again.
+
+          If you believe this is a false positive, reach out in **#security**.
+          EOF
+          )"
+
+      - name: Delete branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ github.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/git/${REF}"


### PR DESCRIPTION
## Summary

- Adds a `delete-vulnerable-branch` job to the zizmor workflow that auto-deletes non-default branches when a high-severity workflow vulnerability is detected on push.
- Closes the attack window where a vulnerable workflow (e.g. `pull_request_target`) is exploitable from the moment it exists on any branch — before a human can review the zizmor finding.
- Creates a GitHub issue assigned to the pusher with context and remediation steps before deleting the branch.

## How it works

1. The existing `zizmor` job runs and fails on a high-severity finding.
2. The new `delete-vulnerable-branch` job triggers (via `always()` + `needs.zizmor.result == 'failure'`).
3. It only acts on `push` events to non-default branches.
4. It opens an issue with details (branch, author, commit, link to logs).
5. It deletes the branch via the GitHub API.

All `${{ }}` expressions are passed through `env:` to prevent template injection.

## Test plan

- [ ] Push a branch with a deliberately vulnerable workflow (e.g. `pull_request_target` with unsanitized input) and verify the branch is deleted and an issue is created.
- [ ] Push a branch with clean workflows and verify the job is skipped.
- [ ] Verify the job does not trigger on `pull_request` or `merge_group` events.
- [ ] Verify the job does not trigger on pushes to the default branch.