### PR TITLE
Add path filters to zizmor workflow triggers

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -1,6 +1,10 @@
 name: zizmor GitHub Actions static analysis
 on:
   push:
+    paths:
+      - '.github/workflows/**'
+      - '**/action.yml'
+      - '**/action.yaml'
   pull_request:
     types:
       - edited
@@ -8,6 +12,10 @@ on:
       - ready_for_review
       - synchronize
       - reopened
+    paths:
+      - '.github/workflows/**'
+      - '**/action.yml'
+      - '**/action.yaml'
   merge_group:
     types: [checks_requested]
 jobs:


### PR DESCRIPTION
## Summary

- Adds `paths` filters to the `push` and `pull_request` triggers so zizmor only runs when workflow files or composite action files are actually changed.
- Matches the same file patterns that `zizmor-check` already searches for: `.github/workflows/**`, `**/action.yml`, `**/action.yaml`.
- `merge_group` is left unfiltered as it does not support `paths`.

This avoids unnecessary zizmor runs on commits that don't touch any actionable files, reducing CI noise and compute.

## Note on required status checks

If `Run zizmor` is configured as a required status check, the workflow not running on unrelated pushes means the check will be "missing" rather than passing. GitHub's default behavior for missing required checks is to block merge. Depending on org settings, you may need to enable "Do not require this check to pass when there are no matching files" or use a status-check bypass approach.

## Test plan

- [ ] Push a commit that only changes a non-workflow file (e.g. README) and verify zizmor does **not** run.
- [ ] Push a commit that changes a file in `.github/workflows/` and verify zizmor runs.
- [ ] Open a PR that modifies an `action.yml` and verify zizmor runs.
- [ ] Verify `merge_group` trigger is unaffected.