### PR TITLE
Enable reusable zizmor auto-delete for dangerous triggers

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -55,5 +55,5 @@ jobs:
       # Reusable workflow gates bench job on org + non-fork PR (OIDC/Vault not available on fork PRs); pass true to opt in.
       send-bench-metrics: true
       auto-delete-dangerous-branches: true
-      auto-delete-slack-channel-id: CHQDPC970
+      auto-delete-slack-channel-id: C011GT1NESU
     secrets: inherit

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,7 +45,7 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@638f24848a49edb0bd14f771b6dd37b4455f1591
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@b57a591ff84c7e03eef6889f80a2350a17ba7cbe
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -54,6 +54,6 @@ jobs:
       extra-args: --offline
       # Reusable workflow gates bench job on org + non-fork PR (OIDC/Vault not available on fork PRs); pass true to opt in.
       send-bench-metrics: true
-      auto-delete-dangerous-branches: ${{ vars.ZIZMOR_SLACK_CHANNEL_ID != '' }}
-      auto-delete-slack-channel-id: ${{ vars.ZIZMOR_SLACK_CHANNEL_ID }}
+      auto-delete-dangerous-branches: true
+      auto-delete-slack-channel-id: CHQDPC970
     secrets: inherit

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,7 +45,7 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@b57a591ff84c7e03eef6889f80a2350a17ba7cbe
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@59249e1e64022197bce704dcbe1546413e23ba2c
     with:
       runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high
@@ -54,6 +54,6 @@ jobs:
       extra-args: --offline
       # Reusable workflow gates bench job on org + non-fork PR (OIDC/Vault not available on fork PRs); pass true to opt in.
       send-bench-metrics: true
-      auto-delete-dangerous-branches: true
+      auto-delete-dangerous-branches: ${{ vars.ZIZMOR_SLACK_CHANNEL_ID != '' }}
       auto-delete-slack-channel-id: ${{ vars.ZIZMOR_SLACK_CHANNEL_ID }}
     secrets: inherit

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -30,13 +30,13 @@ jobs:
           if [ -n "$SEARCH" ]; then
               FOUND_FILES=true
           fi
-          echo "found-files=${FOUND_FILES}" >> $GITHUB_OUTPUT
+          echo "found-files=${FOUND_FILES}" >> "$GITHUB_OUTPUT"
   zizmor:
     name: Run zizmor
 
     permissions:
       actions: read
-      contents: read
+      contents: write
       id-token: write
       pull-requests: write
       security-events: write
@@ -54,4 +54,6 @@ jobs:
       extra-args: --offline
       # Reusable workflow gates bench job on org + non-fork PR (OIDC/Vault not available on fork PRs); pass true to opt in.
       send-bench-metrics: true
+      auto-delete-dangerous-branches: true
+      auto-delete-slack-channel-id: ${{ vars.ZIZMOR_SLACK_CHANNEL_ID }}
     secrets: inherit

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -55,7 +55,7 @@ jobs:
             echo "has_high_critical=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - if: steps.semgrep.outputs.has_findings == 'true'
+      - if: steps.semgrep.outputs.has_findings == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         uses: int128/comment-action@66317511bc86c47bd51e03059040e8a460a167b8
         with:
           update-if-exists: recreate

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: grafana/security-github-actions
-          ref: ${{ github.repository == 'grafana/security-github-actions' && (github.head_ref || github.ref_name) || '' }}
+          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && (github.head_ref || github.ref_name) || 'main' }}
           sparse-checkout: |
             semgrep/custom-rules.yaml
             semgrep/format-results.sh


### PR DESCRIPTION
Enable `auto-delete-dangerous-branches` in the self-zizmor workflow using the reusable workflow from grafana/shared-workflows#1954. Branches with `dangerous-triggers` findings are deleted automatically and a Slack notification is sent.