### PR TITLE
fix: use ubuntu-latest for private repos outside grafana org

### DIFF
--- a/.github/workflows/org-required-trufflehog.yml
+++ b/.github/workflows/org-required-trufflehog.yml
@@ -26,5 +26,5 @@ jobs:
       # Non-blocking: job succeeds; PR still gets comments/artifacts when findings exist
       fail-on-verified: "false"      # Set "true" to fail on verified secrets
       fail-on-unverified: "false"    # Set "true" to fail on unverified secrets
-      runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}    # Use same runner pattern as zizmor
+      runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }}    # grafana private repos use self-hosted ARM64; other orgs use ubuntu-latest
     secrets: inherit

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Check whether there are things to scan
     permissions:
       contents: read
-    runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
+    runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
     outputs:
       found-files: ${{ steps.zizmor-check.outputs.found-files }}
     steps:
@@ -47,7 +47,7 @@ jobs:
 
     uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@638f24848a49edb0bd14f771b6dd37b4455f1591
     with:
-      runs-on: ${{ !github.event.repository.private && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
+      runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
       fail-severity: high
       min-severity: high
       min-confidence: low

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Check whether there are things to scan
     permissions:
       contents: read
-    runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
+    runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }}    # grafana private repos use self-hosted ARM64; other orgs use ubuntu-latest
     outputs:
       found-files: ${{ steps.zizmor-check.outputs.found-files }}
     steps:
@@ -47,7 +47,7 @@ jobs:
 
     uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@638f24848a49edb0bd14f771b6dd37b4455f1591
     with:
-      runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
+      runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }}    # grafana private repos use self-hosted ARM64; other orgs use ubuntu-latest
       fail-severity: high
       min-severity: high
       min-confidence: low


### PR DESCRIPTION
## Summary

- Updates `runs-on` in org-required TruffleHog and zizmor ruleset workflows so private repos outside the `grafana` org use `ubuntu-latest` instead of `ubuntu-arm64-small`.
- Keeps existing behavior for `grafana` private repos (self-hosted `ubuntu-arm64-small`).

Unblocks enterprise ruleset checks (TruffleHog, zizmor) in orgs like `grafana-ps` that do not have the `grafana` self-hosted runner fleet. Revert or narrow this when enterprise/org-scoped runners are available.

## Test plan

- [ ] Merge to `main`
- [ ] Re-run checks on https://github.com/grafana-ps/ps-ai-kit/pull/8 (or push empty commit)
- [ ] Confirm TruffleHog and zizmor jobs start on `ubuntu-latest` and complete (not stuck Queued)