### PR TITLE
fix(periodic-zizmor): migrate GitHub App auth to GATB

### DIFF
--- a/.github/workflows/periodic-zizmor.yaml
+++ b/.github/workflows/periodic-zizmor.yaml
@@ -40,28 +40,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Get GitHub App Secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
         with:
-          common_secrets: |
-            ZIZMOR_APP_ID=zizmor:app-id
-            ZIZMOR_PRIVATE_KEY=zizmor:private-key
-
-      - name: Authenticate App With GitHub
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2
-        id: get-token
-        with:
-          app-id: ${{ env.ZIZMOR_APP_ID }}
-          private-key: ${{ env.ZIZMOR_PRIVATE_KEY }}
-          owner: ${{ matrix.repository.owner }}
-          repositories: |
-            ${{ matrix.repository.repo }}
+          github_app: zizmor
 
       - name: Checkout Target
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           repository: ${{ matrix.repository.owner }}/${{ matrix.repository.repo }}
-          token: ${{ steps.get-token.outputs.token }}
+          token: ${{ steps.get-github-app-token.outputs.token }}
           path: target
           ref: ${{ matrix.repository.ref }}
 
@@ -77,7 +66,7 @@ jobs:
         env:
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
           REPOSITORY: ${{ matrix.repository.owner }}/${{ matrix.repository.repo }}
-          GH_TOKEN: ${{ steps.get-token.outputs.token }}
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
         shell: sh
         run: >-
           uvx zizmor@"${ZIZMOR_VERSION}"
@@ -149,7 +138,7 @@ jobs:
           REF: refs/heads/${{ matrix.repository.ref }}
           SARIF_RESULTS: ${{ steps.prepare-sarif.outputs.results }}
         with:
-          github-token: ${{ steps.get-token.outputs.token }}
+          github-token: ${{ steps.get-github-app-token.outputs.token }}
           script: |
             const { OWNER, REPO, SHA, REF, SARIF_RESULTS } = process.env;
 


### PR DESCRIPTION
## Summary

- Replaces `get-vault-secrets` + `actions/create-github-app-token` with `grafana/shared-workflows/actions/create-github-app-token` for the `zizmor` app.
- Addresses follow-up from #167 and clears the `deny-actions-create-github-app-token` semgrep finding.

## Dependency

Requires deployment_tools GATB config to be merged and applied first:
https://github.com/grafana/deployment_tools/pull/595168

## Test plan

- [ ] Merge deployment_tools GATB config PR and confirm Atlantis apply
- [ ] Merge this PR
- [ ] Trigger or wait for scheduled Periodic Zizmor run; confirm matrix jobs checkout targets and upload SARIF