### PR TITLE
fix(trufflehog): do not upload raw secrets in workflow artifacts

### DIFF
--- a/.github/workflows/org-required-trufflehog.yml
+++ b/.github/workflows/org-required-trufflehog.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   secret-scan:
     name: TruffleHog Secret Scan
-    uses: grafana/security-github-actions/.github/workflows/reusable-trufflehog.yml@fix/trufflehog-artifcat-no-secrets
+    uses: grafana/security-github-actions/.github/workflows/reusable-trufflehog.yml@fix/trufflehog-artifact-no-secrets
     with:
       # Non-blocking: job succeeds; PR still gets comments/artifacts when findings exist
       fail-on-verified: "false"      # Set "true" to fail on verified secrets

--- a/.github/workflows/org-required-trufflehog.yml
+++ b/.github/workflows/org-required-trufflehog.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   secret-scan:
     name: TruffleHog Secret Scan
-    uses: grafana/security-github-actions/.github/workflows/reusable-trufflehog.yml@fix/trufflehog-artifact-no-secrets
+    uses: grafana/security-github-actions/.github/workflows/reusable-trufflehog.yml@main
     with:
       # Non-blocking: job succeeds; PR still gets comments/artifacts when findings exist
       fail-on-verified: "false"      # Set "true" to fail on verified secrets

--- a/.github/workflows/org-required-trufflehog.yml
+++ b/.github/workflows/org-required-trufflehog.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   secret-scan:
     name: TruffleHog Secret Scan
-    uses: grafana/security-github-actions/.github/workflows/reusable-trufflehog.yml@main
+    uses: grafana/security-github-actions/.github/workflows/reusable-trufflehog.yml@fix/trufflehog-artifcat-no-secrets
     with:
       # Non-blocking: job succeeds; PR still gets comments/artifacts when findings exist
       fail-on-verified: "false"      # Set "true" to fail on verified secrets

--- a/.github/workflows/reusable-trufflehog.yml
+++ b/.github/workflows/reusable-trufflehog.yml
@@ -350,6 +350,34 @@ jobs:
             fi
           } > trufflehog_scan.txt
 
+      - name: Sanitize results for artifacts and bench
+        if: always()
+        run: |
+          if [[ -f results.json && -s results.json ]] && jq empty results.json 2>/dev/null; then
+            jq '[.[] | {
+              SourceMetadata,
+              SourceID,
+              SourceType,
+              SourceName,
+              DetectorType,
+              DetectorName,
+              DetectorDescription,
+              DecoderName,
+              Verified,
+              VerificationFromCache,
+              ExtraData: (
+                if (.ExtraData | type) == "object" then
+                  .ExtraData | with_entries(select(.key == "username" or .key == "name" or .key == "url"))
+                else
+                  {}
+                end
+              )
+            }]' results.json > results-sanitized.json
+          else
+            echo "[]" > results-sanitized.json
+          fi
+          rm -f results.json results.ndjson
+
       - name: Copy exclude file into workspace for artifact upload
         if: always()
         run: cp /tmp/trufflehog-exclude.txt trufflehog-exclude.txt 2>/dev/null || true
@@ -361,7 +389,7 @@ jobs:
           name: trufflehog_scan
           path: |
             trufflehog_scan.txt
-            results.json
+            results-sanitized.json
             trufflehog-exclude.txt
           if-no-files-found: warn
           retention-days: 2
@@ -445,4 +473,4 @@ jobs:
             --log-level debug \
             --prometheus-metrics \
             ${EXCLUDE_FLAG} \
-            /tests/results.json
+            /tests/results-sanitized.json


### PR DESCRIPTION
## Summary

- Strips Raw, RawV2, Redacted, and non-safe ExtraData from TruffleHog output before artifact upload.
- Artifacts and Grafana Bench use results-sanitized.json only; full results.json is deleted after PR comments/report generation.

Fixes trufflehog_scan artifacts exposing secret material on public repos.

## Test plan

- [x] Run TruffleHog on a test PR and download trufflehog_scan artifact — no results.json, no Raw in results-sanitized.json
- [x] Confirm bench metrics job still succeeds on a grafana org repo
- [x] Confirm PR comments still show masked findings