### PR TITLE
fix(trufflehog): make bench metrics job non-blocking

### DIFF
--- a/.github/workflows/reusable-trufflehog.yml
+++ b/.github/workflows/reusable-trufflehog.yml
@@ -388,6 +388,7 @@ jobs:
 
   grafana-bench:
     name: Send TruffleHog metrics to Prometheus via Grafana Bench
+    continue-on-error: true
     needs: [trufflehog-scan]
     # Only run for grafana org and non-fork PRs (fork PRs have no OIDC/Vault access).
     if: ${{ github.repository_owner == 'grafana' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && inputs.send-bench-metrics && always() && !cancelled() && (needs.trufflehog-scan.result == 'success' || needs.trufflehog-scan.result == 'failure') }}


### PR DESCRIPTION
Grafana Bench metrics export should not fail the overall workflow when the scan job already completed. Matches shared-workflows zizmor PR #1920.