### PR TITLE
perf(self-zizmor): use native paths filter, drop tautological gating job

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -1,36 +1,37 @@
 name: zizmor GitHub Actions static analysis
 on:
+  # Source-repo runs only. Required-workflow consumers don't use `push:`.
   push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**/*.yml'
+      - '.github/workflows/**/*.yaml'
+      - '**/action.yml'
+      - '**/action.yaml'
+  # What the org ruleset invokes in every target repo.
+  # Required workflows that are skipped via paths filtering are reported as
+  # passing, so this is safe under the "Require workflows to pass before
+  # merging" ruleset.
+  # https://docs.github.com/en/actions/concepts/security/required-workflows
   pull_request:
     types:
-      - edited
       - opened
       - ready_for_review
       - synchronize
       - reopened
+    paths:
+      - '.github/workflows/**/*.yml'
+      - '.github/workflows/**/*.yaml'
+      - '**/action.yml'
+      - '**/action.yaml'
   merge_group:
     types: [checks_requested]
+
+concurrency:
+  group: zizmor-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  zizmor-check:
-    name: Check whether there are things to scan
-    permissions:
-      contents: read
-    runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }}    # grafana private repos use self-hosted ARM64; other orgs use ubuntu-latest
-    outputs:
-      found-files: ${{ steps.zizmor-check.outputs.found-files }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - name: Run zizmor
-        id: zizmor-check
-        shell: bash
-        run: |
-          FOUND_FILES=false
-          SEARCH=$(find . -path "**/.github/workflows/*.yml" -o -path "**/.github/workflows/*.yaml" -o -path "**/action.yml" -o -path "**/action.yaml")
-          if [ -n "$SEARCH" ]; then
-              FOUND_FILES=true
-          fi
-          echo "found-files=${FOUND_FILES}" >> $GITHUB_OUTPUT
   zizmor:
     name: Run zizmor
 
@@ -40,10 +41,6 @@ jobs:
       id-token: write
       pull-requests: write
       security-events: write
-
-    needs:
-      - zizmor-check
-    if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
     uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@638f24848a49edb0bd14f771b6dd37b4455f1591
     with:


### PR DESCRIPTION
## Summary

`self-zizmor.yaml` is propagated as a required workflow via an org ruleset (`Require workflows to pass before merging`, targeting default branches of all repos). That means every change here multiplies across the org, and so do the wastes.

This PR makes three small, safe changes:

1. **Delete the `zizmor-check` gating job.** The `find` is a tautology — `self-zizmor.yaml` itself lives in `.github/workflows/`, so the match is guaranteed. The job spends a runner-minute + full checkout to report `true` ~100% of the time.
2. **Move the gating to a native `on: paths:` filter** on `pull_request:` (and a scoped `push:` for source-repo runs). PRs that don't touch workflows or composite actions never spin up a runner.
3. **Drop `edited` from `pull_request.types`** and add a `concurrency` group so PR force-pushes cancel in-flight runs.

### Why this is safe under the org ruleset

GitHub's required-workflows docs:

> If a required workflow is skipped due to path filtering, branch filtering, or a commit message, then the check associated with that workflow will pass.

So a PR that doesn't touch workflow/action files → `Run zizmor` is skipped → the ruleset reports ✅. No sentinel job needed, no security regression — the `paths:` filter exactly matches zizmor's scan scope, so any PR that the filter excludes has nothing for zizmor to find anyway.

### Diff at a glance

- `on: pull_request:` gains a `paths:` filter mirroring zizmor's scan scope and drops the `edited` type.
- `on: push:` gains `branches: [main]` + the same `paths:` filter. This trigger only fires in this repo; consumer repos are driven by the ruleset's `pull_request` injection.
- New `concurrency:` block keyed on PR number / ref, with `cancel-in-progress` on PRs only.
- `zizmor-check` job removed.
- `zizmor` job loses its `needs:` / `if:` on the deleted gate.

### Expected impact

Per-event, per-repo savings on the gate job alone: one runner-minute + checkout, every PR/push/merge, on every repo in the org. The bigger win is on PRs that touch nothing zizmor cares about (the common case in repos like `grafana/deployment_tools`) — those now do zero work instead of two jobs' worth.

## Follow-ups (not in this PR)

A couple of upstream changes to `grafana/shared-workflows`'s `reusable-zizmor.yml` would compound across the org but are out of scope here:

- `fetch-depth: 1` on the `analysis` job's checkout — zizmor only reads the working tree.
- A `skip-default-config` input so repos that ship `.github/zizmor.yml` can skip the `job-workflow-ref` job (Node + `jose` install just to verify an OIDC token).