### PR TITLE
Bump reusable-zizmor to support auto-delete on pull_request events

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,7 +45,7 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@59249e1e64022197bce704dcbe1546413e23ba2c
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@648a1ae89644f82fe65879db7da94de7ff79006a
     with:
       runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }}    # grafana private repos use self-hosted ARM64; other orgs use ubuntu-latest
       fail-severity: high


### PR DESCRIPTION
Pin reusable-zizmor to grafana/shared-workflows#1975, which adds `pull_request` event support to the auto-delete job. This is needed for org-required workflows deployed via rulesets, which only fire `pull_request` events.