### PR TITLE
Bump reusable-zizmor to include payload-templated fix

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,7 +45,7 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@648a1ae89644f82fe65879db7da94de7ff79006a
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@acf6456bac4ea5991c8b1c4466b85e8b94d9a542
     with:
       runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }}    # grafana private repos use self-hosted ARM64; other orgs use ubuntu-latest
       fail-severity: high


### PR DESCRIPTION
Pin reusable-zizmor to grafana/shared-workflows#1976, which fixes the `payload-templated` YAML boolean error in the Slack notification step.