### PR TITLE
chore(self-zizmor): pin to latest commit of reusable-zizmor

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,7 +45,7 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@71b1332d79a220b65c63442f57661823e81e73aa
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@829aef098ea86ba0e61e74f895c00c9a8cc1fba9
     with:
       runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }} # grafana private repos use self-hosted ARM64; other orgs use ubuntu-latest
       fail-severity: high


### PR DESCRIPTION
Bumps the the pin for `reusable-zizmor.yml` to pick up https://github.com/grafana/shared-workflows/pull/2123, which removes the temporary PR comment flagging workflow jobs with no `permissions:` block.