### PR TITLE
ci: use ubuntu-any-minus runners for zizmor and trufflehog

### DIFF
--- a/.github/workflows/org-required-trufflehog.yml
+++ b/.github/workflows/org-required-trufflehog.yml
@@ -26,5 +26,5 @@ jobs:
       # Non-blocking: job succeeds; PR still gets comments/artifacts when findings exist
       fail-on-verified: "false"      # Set "true" to fail on verified secrets
       fail-on-unverified: "false"    # Set "true" to fail on unverified secrets
-      runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }}    # grafana private repos use self-hosted ARM64; other orgs use ubuntu-latest
+      runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-any-minus' }}    # grafana private repos use self-hosted runners (any arch, medium or smaller); other orgs use ubuntu-latest
     secrets: inherit

--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Check whether there are things to scan
     permissions:
       contents: read
-    runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }} # grafana private repos use self-hosted ARM64; other orgs use ubuntu-latest
+    runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-any-minus' }} # grafana private repos use self-hosted runners (any arch, medium or smaller); other orgs use ubuntu-latest
     outputs:
       found-files: ${{ steps.zizmor-check.outputs.found-files }}
     steps:
@@ -47,7 +47,7 @@ jobs:
 
     uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@829aef098ea86ba0e61e74f895c00c9a8cc1fba9
     with:
-      runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }} # grafana private repos use self-hosted ARM64; other orgs use ubuntu-latest
+      runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-any-minus' }} # grafana private repos use self-hosted runners (any arch, medium or smaller); other orgs use ubuntu-latest
       fail-severity: high
       min-severity: high
       min-confidence: low


### PR DESCRIPTION
Switch the self-zizmor and org-required-trufflehog jobs on grafana private repos from the exact `ubuntu-arm64-small` label to `ubuntu-any-minus` (any architecture, at most the default/medium size). These scans are light, so letting them land on any small or medium runner on either architecture reduces queueing when the arm64-small pool is short.

Depends on grafana/deployment_tools#662206 being applied — the `-minus` label family doesn't exist on the runners until then.