### PR TITLE
chore(self-zizmor): pin reusable-zizmor for collection-ignore

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,7 +45,7 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@829aef098ea86ba0e61e74f895c00c9a8cc1fba9
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@f206fa553f788616be56dadc0c38e921cc847d91
     with:
       runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-any-minus' }} # grafana private repos use self-hosted runners (any arch, medium or smaller); other orgs use ubuntu-latest
       fail-severity: high


### PR DESCRIPTION
## Summary

Bumps the `reusable-zizmor.yml` pin to pick up https://github.com/grafana/shared-workflows/pull/1945, which adds optional `.github/zizmor-collection-ignore` support so repos can exclude vendored trees from org zizmor scans.

Pin: `829aef098ea86ba0e61e74f895c00c9a8cc1fba9` → `f206fa553f788616be56dadc0c38e921cc847d91`

## Test plan

- [x] Confirm org ruleset / self-zizmor runs against the new SHA after merge
- [x] Optional: in a pilot repo with `.github/zizmor-collection-ignore`, confirm ignored vendored workflows are skipped
