### PR TITLE
chore(self-zizmor): pin reusable-zizmor for collection-paths v0.2.0

### DIFF
--- a/.github/workflows/self-zizmor.yaml
+++ b/.github/workflows/self-zizmor.yaml
@@ -45,7 +45,7 @@ jobs:
       - zizmor-check
     if: ${{ needs.zizmor-check.outputs.found-files == 'true' }}
 
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@f206fa553f788616be56dadc0c38e921cc847d91
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@235a1525040c13d386356d66952c779f81cccbc0
     with:
       runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-any-minus' }} # grafana private repos use self-hosted runners (any arch, medium or smaller); other orgs use ubuntu-latest
       fail-severity: high


### PR DESCRIPTION
## Summary

Bumps the `reusable-zizmor.yml` pin to pick up https://github.com/grafana/shared-workflows/pull/2251, which re-pins `zizmor-collection-paths` to the `v0.2.0` release tag.

Pin: `f206fa553f788616be56dadc0c38e921cc847d91` → `235a1525040c13d386356d66952c779f81cccbc0`

This is hygiene only . This aligns the org ruleset with the released action pin for Renovate tracking.

## Test plan

- [ ] Confirm self-zizmor / org ruleset runs against the new SHA after merge