### PR TITLE
chore(semgrep): deny outdated create-github-app-token versions

### DIFF
--- a/semgrep/custom-rules.yaml
+++ b/semgrep/custom-rules.yaml
@@ -11,3 +11,18 @@ rules:
       approved [alternative for generating GitHub App tokens](https://enghub.grafana-ops.net/docs/default/component/deployment-tools/platform/vault/github-app-token-broker-migration-guide/).
     languages: [generic]
     severity: LOW
+  - id: deny-outdated-create-github-app-token-versions
+    patterns:
+      - pattern-regex: "uses:\\s*grafana/shared-workflows/actions/create-github-app-token@(v0\\.2(\\.[0-3])?\\b|v0\\.3\\.0\\b|795f748a236f9de024b7514efc9a208456e7e468|259ba21cb3ff07724f331e26d926d655d24b317b|ae92934a14a48b94494dbc06d74a81d47fe08a40|a5556630f6557d54926f9e2b63e68702a1684315|eb02241ed0a92aff205feab8ac3afcdf51c757c8)"
+    paths:
+      include:
+        - "*.yaml"
+        - "*.yml"
+    message: >
+      This version of grafana/shared-workflows/actions/create-github-app-token
+      is outdated and has been disabled at the organization level; workflows
+      using it will fail at runtime. Update to
+      grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e
+      (create-github-app-token/v0.3.1) or later.
+    languages: [generic]
+    severity: HIGH


### PR DESCRIPTION
## Summary

- Adds an org-wide Semgrep rule flagging pins of `grafana/shared-workflows/actions/create-github-app-token` older than v0.3.1 (tags v0.2–v0.3.0 and their SHAs).
- These versions are disabled at the organization level, so workflows referencing them fail at runtime. This rule surfaces the problem at PR time instead, with the fixed pin to use: `46f48da11e78ebdba7a8747ae456b11062fac83e` (create-github-app-token/v0.3.1).
- Severity HIGH so affected PRs fail the Semgrep check.

## Test plan

- [x] Regex unit-tested: matches all outdated tags/SHAs; does not match the v0.3.1 pin, newer tags, or the upstream `actions/create-github-app-token`
- [x] Rule does not self-flag this repo
- [x] Semgrep workflow green on this PR