### PR TITLE
fix(trufflehog): fail the org-required scan on verified secrets

### DIFF
--- a/.github/workflows/org-required-trufflehog.yml
+++ b/.github/workflows/org-required-trufflehog.yml
@@ -23,8 +23,8 @@ jobs:
     name: TruffleHog Secret Scan
     uses: grafana/security-github-actions/.github/workflows/reusable-trufflehog.yml@0380389a5fad89a566ff9c2eb6ccc402c629e69d # main
     with:
-      # Non-blocking: job succeeds; PR still gets comments/artifacts when findings exist
-      fail-on-verified: "false"      # Set "true" to fail on verified secrets
-      fail-on-unverified: "false"    # Set "true" to fail on unverified secrets
+      # Blocking: verified secrets fail the required workflow; unverified stay comments-only
+      fail-on-verified: "true"       # Block PRs with verified secrets
+      fail-on-unverified: "false"    # Don't block on unverified secrets
       runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-any-minus' }}    # grafana private repos use self-hosted runners (any arch, medium or smaller); other orgs use ubuntu-latest
     secrets: inherit


### PR DESCRIPTION
The org-required wrapper has been in monitoring mode since #137 (`fail-on-verified: false`). Flip it back to true so verified secrets fail the required workflow and block merge. Unverified findings stay comments-only.

Test/example values that still verify can use `trufflehog:ignore`:
https://github.com/grafana/security-docs/blob/main/docs/appsec/security-tools/trufflehog.md

No reusable-workflow pin bump — the ruleset already runs this file from `main`.