### PR TITLE
feat(trufflehog): add org-wide custom detector support

### DIFF
--- a/.github/workflows/reusable-trufflehog.yml
+++ b/.github/workflows/reusable-trufflehog.yml
@@ -58,7 +58,7 @@ jobs:
         run: git fetch --depth=1 origin "${MERGE_GROUP_BASE_SHA}" "${MERGE_GROUP_HEAD_SHA}"
 
       - name: Remove persisted credentials
-        run: git config --unset-all http.https://github.com/.extraheader
+        run: git config --unset-all http.https://github.com/.extraheader || true
 
       - name: Fetch org-wide TruffleHog exclude patterns
         env:

--- a/.github/workflows/reusable-trufflehog.yml
+++ b/.github/workflows/reusable-trufflehog.yml
@@ -105,6 +105,40 @@ jobs:
           echo "--- effective exclude patterns ---"
           cat "${DEST}"
 
+      - name: Fetch org-wide TruffleHog custom detectors
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          DEST=/tmp/trufflehog-custom-detectors.yaml
+          REPO=grafana/security-github-actions
+          FILE_PATH=trufflehog/custom-detectors.yaml
+
+          # Resolve the ref the calling workflow used (e.g. @main, @feature/branch, @v1).
+          CALLER_REF="main"
+          if [[ -n "${WORKFLOW_REF}" ]]; then
+            CALLER_REF=$(echo "${WORKFLOW_REF}" | sed 's|.*@||; s|^refs/heads/||; s|^refs/tags/||')
+          fi
+
+          LOADED=false
+          for REF in main "${CALLER_REF}"; do
+            [[ "$LOADED" == "true" ]] && break
+            if gh api "repos/${REPO}/contents/${FILE_PATH}?ref=${REF}" \
+                -H "Accept: application/vnd.github.v3.raw" -o "${DEST}" 2>/dev/null && [[ -s "${DEST}" ]]; then
+              echo "Loaded custom detectors from ${REPO}@${REF} (GitHub API)"
+              LOADED=true
+            elif curl -fsSL "https://raw.githubusercontent.com/${REPO}/${REF}/${FILE_PATH}" \
+                -o "${DEST}" 2>/dev/null && [[ -s "${DEST}" ]]; then
+              echo "Loaded custom detectors from raw.githubusercontent.com@${REF}"
+              LOADED=true
+            fi
+          done
+
+          if [[ "$LOADED" != "true" ]]; then
+            echo "::warning::Could not fetch TruffleHog custom detectors from ${REPO} (tried main and ${CALLER_REF}). Scanning with built-in detectors only."
+            rm -f "${DEST}"
+          fi
+
       - name: Install TruffleHog
         run: |
           # Download binary directly from GitHub releases for supply chain security
@@ -136,6 +170,12 @@ jobs:
 
           # Extract non-comment, non-blank patterns for the shell pre-filter.
           grep -vE '^\s*#|^\s*$' /tmp/trufflehog-exclude.txt > /tmp/exclude-regexes.txt 2>/dev/null || true
+
+          # Org-wide custom detectors (optional; scan proceeds without them if the fetch failed).
+          CONFIG_FLAG=""
+          if [[ -s /tmp/trufflehog-custom-detectors.yaml ]]; then
+            CONFIG_FLAG="--config /tmp/trufflehog-custom-detectors.yaml"
+          fi
 
           if [[ "${EVENT_NAME}" == "pull_request" ]] || [[ "${EVENT_NAME}" == "merge_group" ]]; then
             if [[ "${EVENT_NAME}" == "pull_request" ]]; then
@@ -169,6 +209,7 @@ jobs:
                 trufflehog filesystem . \
                   --include-paths "${INCLUDE_REGEXES}" \
                   --exclude-paths /tmp/trufflehog-exclude.txt \
+                  ${CONFIG_FLAG} \
                   --concurrency 16 \
                   --json \
                   --no-update \
@@ -181,7 +222,7 @@ jobs:
             fi
           else
             echo "Scanning current filesystem..."
-            trufflehog filesystem . --exclude-paths /tmp/trufflehog-exclude.txt --concurrency 16 --json --no-update --results=verified,unverified > results.ndjson || true
+            trufflehog filesystem . --exclude-paths /tmp/trufflehog-exclude.txt ${CONFIG_FLAG} --concurrency 16 --json --no-update --results=verified,unverified > results.ndjson || true
           fi
 
           # Process results and filter git hashes from CHANGELOG files
@@ -273,7 +314,7 @@ jobs:
             FINDINGS=$(jq -r '.[] |
               "- " +
               (if .Verified then "**VERIFIED SECRET**" else "**Possible secret**" end) +
-              " (" + .DetectorName + ") at `" +
+              " (" + .DetectorName + ((.ExtraData.name? // "") | if length > 0 then ": " + . else "" end) + ") at `" +
               (((try .SourceMetadata.Data.Filesystem.file catch null) // (try .SourceMetadata.Data.Git.file catch null)) // "unknown") +
               ":" +
               (((try .SourceMetadata.Data.Filesystem.line catch null) // (try .SourceMetadata.Data.Git.line catch null)) | tostring) +
@@ -344,7 +385,7 @@ jobs:
             echo ""
             echo "Detailed Results:"
             if [[ -f "results.json" && -s "results.json" ]] && jq empty results.json 2>/dev/null; then
-              jq -r '.[] | "- " + (if .Verified then "VERIFIED" else "Unverified" end) + " " + .DetectorName + " at " + (((try .SourceMetadata.Data.Filesystem.file catch null) // (try .SourceMetadata.Data.Git.file catch null)) // "unknown") + ":" + (((try .SourceMetadata.Data.Filesystem.line catch null) // (try .SourceMetadata.Data.Git.line catch null)) | tostring) + " → " + (if (.Raw | length) > 8 then (.Raw[:4] + "***" + .Raw[-4:]) else "***" end)' results.json 2>/dev/null || echo "Error processing results"
+              jq -r '.[] | "- " + (if .Verified then "VERIFIED" else "Unverified" end) + " " + .DetectorName + ((.ExtraData.name? // "") | if length > 0 then ": " + . else "" end) + " at " + (((try .SourceMetadata.Data.Filesystem.file catch null) // (try .SourceMetadata.Data.Git.file catch null)) // "unknown") + ":" + (((try .SourceMetadata.Data.Filesystem.line catch null) // (try .SourceMetadata.Data.Git.line catch null)) | tostring) + " → " + (if (.Raw | length) > 8 then (.Raw[:4] + "***" + .Raw[-4:]) else "***" end)' results.json 2>/dev/null || echo "Error processing results"
             else
               echo "No secrets detected"
             fi

--- a/.github/workflows/reusable-trufflehog.yml
+++ b/.github/workflows/reusable-trufflehog.yml
@@ -63,7 +63,7 @@ jobs:
         run: git fetch --depth=1 origin "${MERGE_GROUP_BASE_SHA}" "${MERGE_GROUP_HEAD_SHA}"
 
       - name: Remove persisted credentials
-        run: git config --unset-all http.https://github.com/.extraheader || true
+        run: git config --unset-all http.https://github.com/.extraheader
 
       - name: Fetch org-wide TruffleHog exclude patterns
         env:

--- a/.github/workflows/reusable-trufflehog.yml
+++ b/.github/workflows/reusable-trufflehog.yml
@@ -63,7 +63,7 @@ jobs:
         run: git fetch --depth=1 origin "${MERGE_GROUP_BASE_SHA}" "${MERGE_GROUP_HEAD_SHA}"
 
       - name: Remove persisted credentials
-        run: git config --unset-all http.https://github.com/.extraheader
+        run: git config --unset-all http.https://github.com/.extraheader || true
 
       - name: Fetch org-wide TruffleHog exclude patterns
         env:

--- a/.github/workflows/reusable-trufflehog.yml
+++ b/.github/workflows/reusable-trufflehog.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: true
         type: boolean
+      custom-detectors-ref:
+        description: "Git ref in grafana/security-github-actions to fetch trufflehog/custom-detectors.yaml from. Tried before main. Leave empty for org-wide (loads from main)."
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -109,20 +114,33 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           WORKFLOW_REF: ${{ github.workflow_ref }}
+          DETECTORS_REF: ${{ inputs.custom-detectors-ref }}
         run: |
           DEST=/tmp/trufflehog-custom-detectors.yaml
           REPO=grafana/security-github-actions
           FILE_PATH=trufflehog/custom-detectors.yaml
 
-          # Resolve the ref the calling workflow used (e.g. @main, @feature/branch, @v1).
+          # github.workflow_ref is the *caller* (e.g. a consumer PR merge ref), not
+          # this reusable workflow's branch. Prefer an explicit input for pre-merge tests.
           CALLER_REF="main"
           if [[ -n "${WORKFLOW_REF}" ]]; then
             CALLER_REF=$(echo "${WORKFLOW_REF}" | sed 's|.*@||; s|^refs/heads/||; s|^refs/tags/||')
           fi
 
+          REFS=()
+          if [[ -n "${DETECTORS_REF}" ]]; then
+            REFS+=("${DETECTORS_REF}")
+          fi
+          REFS+=("main")
+          if [[ -n "${CALLER_REF}" && "${CALLER_REF}" != "main" && "${CALLER_REF}" != "${DETECTORS_REF}" ]]; then
+            REFS+=("${CALLER_REF}")
+          fi
+
           LOADED=false
-          for REF in main "${CALLER_REF}"; do
+          TRIED=""
+          for REF in "${REFS[@]}"; do
             [[ "$LOADED" == "true" ]] && break
+            TRIED="${TRIED} ${REF}"
             if gh api "repos/${REPO}/contents/${FILE_PATH}?ref=${REF}" \
                 -H "Accept: application/vnd.github.v3.raw" -o "${DEST}" 2>/dev/null && [[ -s "${DEST}" ]]; then
               echo "Loaded custom detectors from ${REPO}@${REF} (GitHub API)"
@@ -135,7 +153,7 @@ jobs:
           done
 
           if [[ "$LOADED" != "true" ]]; then
-            echo "::warning::Could not fetch TruffleHog custom detectors from ${REPO} (tried main and ${CALLER_REF}). Scanning with built-in detectors only."
+            echo "::warning::Could not fetch TruffleHog custom detectors from ${REPO} (tried${TRIED}). Scanning with built-in detectors only."
             rm -f "${DEST}"
           fi
 

--- a/trufflehog/custom-detectors.yaml
+++ b/trufflehog/custom-detectors.yaml
@@ -1,0 +1,13 @@
+# Org-wide custom TruffleHog detectors, fetched at scan time by
+# .github/workflows/reusable-trufflehog.yml. Complements the built-in
+# detectors for formats the pinned TruffleHog release does not cover yet.
+detectors:
+  # GitHub App installation tokens in the JWT-based format
+  # (ghs_<app id>_<JWT>, ~520 chars, variable length). See:
+  # https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/
+  # Remove once the pinned TruffleHog release detects this format natively.
+  - name: github-app-installation-token-jwt
+    keywords:
+      - ghs_
+    regex:
+      token: 'ghs_[0-9]+_eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+'

--- a/trufflehog/custom-detectors.yaml
+++ b/trufflehog/custom-detectors.yaml
@@ -1,6 +1,9 @@
 # Org-wide custom TruffleHog detectors, fetched at scan time by
 # .github/workflows/reusable-trufflehog.yml. Complements the built-in
 # detectors for formats the pinned TruffleHog release does not cover yet.
+#
+# Custom detectors are regex-only unless a verify webhook is configured.
+# Without verify, matches are unverified (PR comments, do not block merge).
 detectors:
   # GitHub App installation tokens in the JWT-based format
   # (ghs_<app id>_<JWT>, ~520 chars, variable length). See:
@@ -11,3 +14,43 @@ detectors:
       - ghs_
     regex:
       token: 'ghs_[0-9]+_eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+'
+
+  # Grafana Cloud prod tokens that are not the JWT-shaped glc_eyJ keys
+  # already covered by the built-in Grafana detector.
+  # From grafana/pii-secret-research .betterleaks.toml (no CEL verify here).
+  # exclude_words is a case-insensitive contains() on a lowercased token, so
+  # these values must be lowercase or they will not match.
+  - name: grafana-cloud-api-token
+    keywords:
+      - glc_
+    exclude_words:
+      - glc_eyj
+      - glc_dev_
+      - glc_ops_
+    regex:
+      token: '\b(glc_[A-Za-z0-9+/]{32,400}={0,3})'
+
+  # Grafana Cloud dev tokens (glc_dev_). Not in upstream TruffleHog.
+  - name: grafana-cloud-dev-api-token
+    keywords:
+      - glc_dev_
+    regex:
+      token: '\b(glc_dev_[A-Za-z0-9_+/=-]{20,})\b'
+
+  # Grafana Cloud ops tokens (glc_ops_). Not in upstream TruffleHog.
+  - name: grafana-cloud-ops-api-token
+    keywords:
+      - glc_ops_
+    regex:
+      token: '\b(glc_ops_[A-Za-z0-9_+/=-]{20,})\b'
+
+  # SA tokens next to grafana-ops.net / grafana-dev.net in the same chunk.
+  # Built-in GrafanaServiceAccount already covers glsa_ + *.grafana.net.
+  # Both named regexes must match. Raw is token then url (sorted key names).
+  - name: grafana-service-account-token-ops-dev
+    keywords:
+      - glsa_
+    primary_regex_name: token
+    regex:
+      token: '\b(glsa_[A-Za-z0-9_+/=-]{20,})\b'
+      url: '\b([a-zA-Z0-9-]+\.grafana-(?:ops|dev)\.net)\b'


### PR DESCRIPTION
## Summary

- The reusable TruffleHog workflow now loads org-wide custom detectors from `trufflehog/custom-detectors.yaml`, fetched at scan time the same way as the existing exclude patterns and passed via `--config`. If the fetch fails, the scan proceeds with built-in detectors only.
- GitHub App installation tokens in the new `ghs_<app id>_<JWT>` format ([GitHub changelog, April 2026](https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/)). The pinned TruffleHog release does not match this format yet — the built-in detector cuts the match at the first `.` (upstream fix pending in trufflesecurity/trufflehog#5156). The detector can be removed once a release covering the format is pinned.
- Grafana-internal Cloud token formats from `.betterleaks.toml` (regex-only, unverified comments; do not block merge):
  - `glc_dev_` / `glc_ops_` (not in upstream TruffleHog)
  - broader prod `glc_` excluding `glc_eyJ` (built-in Grafana detector still owns JWT-shaped keys)
  - `glsa_` next to `grafana-ops.net` / `grafana-dev.net` (built-in still owns `glsa_` + `*.grafana.net`)
- PR comments and scan reports now label custom detector findings with the detector name (`CustomRegex: github-app-installation-token-jwt`) instead of the bare `CustomRegex`.
- `custom-detectors-ref` input: fetch detectors from an explicit ref (needed when the caller is a different repo/PR). After merge, org-required can keep omitting it; fetch tries `main` first.
- `Remove persisted credentials` uses `|| true` so checkout v7 (no extraheader) does not fail the job. Org pin is still checkout v4 until a follow-up pin bump.

## Testing

- Ran the pinned TruffleHog version (v3.95.9) locally with this config against synthetic fixtures: full-length (~520-char) new-format tokens match in full, legacy 36-char tokens remain covered by the built-in detector, and decoy strings (`ghs_config.yaml`, stray `eyJ`, bare app IDs) produce no findings.
- Grafana detectors fixture-tested with TruffleHog 3.95.2 (`--include-detectors=CustomRegex --no-verification`): `glc_dev_` / `glc_ops_` / non-JWT `glc_` / `glsa_`+ops-dev URL match; `glc_eyJ`, `glsa_` with only `grafana.net`, `glsa_` with no URL, and decoys do not.
- Full scan of this repository with the new config: zero findings (no self-flagging).
- Verified the findings rendering for results with and without `ExtraData.name`.
- Live call from throwaway [grafana/security-appsec#669](https://github.com/grafana/security-appsec/pull/669) (`reusable-trufflehog.yml@appsec/trufflehog-custom-detectors`, `fail-on-verified/unverified: false`): [run 32292678395](https://github.com/grafana/security-appsec/actions/runs/32292678395) succeeded. Extraheader unset did not fail. Loaded custom detectors from this branch. 0 verified / 6 unverified (Jo's four Grafana CustomRegex + Charline's `github-app-installation-token-jwt` + built-in Github truncated dual-hit). Do not merge that test PR.

Note: while the pinned release lags upstream, a new-format GitHub App token yields two findings (the full custom match plus the built-in detector's truncated fragment). Both are reported; this resolves itself when the upstream fix ships and the custom detector is removed.

Custom Grafana detectors have no verify webhook, so matches are unverified and will not fail the required check.

Follow-up after squash-merge: bump `org-required-trufflehog.yml` `uses:` to the merge SHA. Merging this PR does not change org-wide scans by itself.
