### PR TITLE
chore(deps): pin reusable-trufflehog to 7da08dc

### DIFF
--- a/.github/workflows/org-required-trufflehog.yml
+++ b/.github/workflows/org-required-trufflehog.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   secret-scan:
     name: TruffleHog Secret Scan
-    uses: grafana/security-github-actions/.github/workflows/reusable-trufflehog.yml@0380389a5fad89a566ff9c2eb6ccc402c629e69d # main
+    uses: grafana/security-github-actions/.github/workflows/reusable-trufflehog.yml@7da08dc6773bde8f8f7dd0427fd42989a8367715 # main (#213)
     with:
       # Blocking: verified secrets fail the required workflow; unverified stay comments-only
       fail-on-verified: "true"       # Block PRs with verified secrets


### PR DESCRIPTION
## Summary

- Pin the org-required TruffleHog wrapper to `7da08dc` (`#213`) so the ruleset actually runs custom detectors, `custom-detectors-ref`, and the checkout v7 extraheader `|| true` fix.
- `fail-on-verified: true` is unchanged. Custom Grafana detectors are regex-only (unverified comments; they do not block merge).
- Do not pass `custom-detectors-ref` here: after `#213`, fetch tries `main` first.

Until this merges, org scans stay on `0380389a` (checkout v4, no custom detectors).

## Test plan

- [x] Confirm `uses:` is `reusable-trufflehog.yml@7da08dc6773bde8f8f7dd0427fd42989a8367715`
- [x] After merge, a grafana-org PR should log loading `trufflehog/custom-detectors.yaml` from main
- [x] Verified secrets still fail the required check; unverified custom hits stay comments-only
